### PR TITLE
Refactor to programmatic usage

### DIFF
--- a/config/autoload/middleware-pipeline.global.php
+++ b/config/autoload/middleware-pipeline.global.php
@@ -1,74 +1,12 @@
 <?php
 use Zend\Expressive\Container\ApplicationFactory;
 use Zend\Expressive\Helper;
-//use Zend\ServiceManager\Factory\InvokableFactory;
 
 return [
     'dependencies' => [
         'factories' => [
             Helper\ServerUrlMiddleware::class => Helper\ServerUrlMiddlewareFactory::class,
             Helper\UrlHelperMiddleware::class => Helper\UrlHelperMiddlewareFactory::class,
-        ],
-    ],
-    // This can be used to seed pre- and/or post-routing middleware
-    'middleware_pipeline' => [
-        // An array of middleware to register. Each item is of the following
-        // specification:
-        //
-        // [
-        //  Required:
-        //     'middleware' => 'Name or array of names of middleware services and/or callables',
-        //  Optional:
-        //     'path'     => '/path/to/match', // string; literal path prefix to match
-        //                                     // middleware will not execute
-        //                                     // if path does not match!
-        //     'error'    => true, // boolean; true for error middleware
-        //     'priority' => 1, // int; higher values == register early;
-        //                      // lower/negative == register last;
-        //                      // default is 1, if none is provided.
-        // ],
-        //
-        // While the ApplicationFactory ignores the keys associated with
-        // specifications, they can be used to allow merging related values
-        // defined in multiple configuration files/locations. This file defines
-        // some conventional keys for middleware to execute early, routing
-        // middleware, and error middleware.
-        'always' => [
-            'middleware' => [
-                // Add more middleware here that you want to execute on
-                // every request:
-                // - bootstrapping
-                // - pre-conditions
-                // - modifications to outgoing responses
-                Helper\ServerUrlMiddleware::class,
-                Helper\ServerUrlMiddleware::class,
-                App\Middleware\TheClacksMiddleware::class,
-                App\Middleware\UuidMiddleware::class,
-                App\Middleware\RequestTimeMiddleware::class,
-            ],
-            'priority' => 10000,
-        ],
-
-        'routing' => [
-            'middleware' => [
-                ApplicationFactory::ROUTING_MIDDLEWARE,
-                Helper\UrlHelperMiddleware::class,
-                // Add more middleware here that needs to introspect the routing
-                // results; this might include:
-                // - route-based authentication
-                // - route-based validation
-                // - etc.
-                ApplicationFactory::DISPATCH_MIDDLEWARE,
-            ],
-            'priority' => 1,
-        ],
-
-        'error' => [
-            'middleware' => [
-                // Add error middleware here.
-            ],
-            'error'    => true,
-            'priority' => -10000,
         ],
     ],
 ];

--- a/config/autoload/routes.global.php
+++ b/config/autoload/routes.global.php
@@ -13,37 +13,4 @@ return [
             App\Action\UserDbalListAction::class => App\Action\UserDbalListFactory::class,
         ],
     ],
-
-    'routes' => [
-        [
-            'name' => 'home',
-            'path' => '/',
-            'middleware' => App\Action\HomePageAction::class,
-            'allowed_methods' => ['GET'],
-        ],
-        [
-            'name' => 'api.ping',
-            'path' => '/api/ping',
-            'middleware' => App\Action\PingAction::class,
-            'allowed_methods' => ['GET'],
-        ],
-        [
-            'name' => 'page',
-            'path' => '/page/[{action}]',
-            'middleware' => App\Action\PageAction::class,
-            'allowed_methods' => ['GET'],
-        ],
-        [
-            'name' => 'user.list',
-            'path' => '/users',
-            'middleware' => App\Action\UserListAction::class,
-            'allowed_methods' => ['GET'],
-        ],
-        [
-            'name' => 'user.dbal.list',
-            'path' => '/users/dbal',
-            'middleware' => App\Action\UserDbalListAction::class,
-            'allowed_methods' => ['GET'],
-        ],
-    ],
 ];

--- a/public/index.php
+++ b/public/index.php
@@ -1,6 +1,9 @@
 <?php
 
-use App\Middleware\TheClacksMiddleware;
+namespace App;
+
+use Zend\Expressive\Application;
+use Zend\Expressive\Helper;
 
 // Delegate static file requests back to the PHP built-in webserver
 if (php_sapi_name() === 'cli-server'
@@ -16,8 +19,23 @@ require 'vendor/autoload.php';
 $container = require 'config/container.php';
 
 /** @var \Zend\Expressive\Application $app */
-$app = $container->get(\Zend\Expressive\Application::class);
+$app = $container->get(Application::class);
 
-//$app->pipe(TheClacksMiddleware::class);
+// Create pipeline
+$app->pipe(Helper\ServerUrlMiddleware::class);
+$app->pipe(Middleware\TheClacksMiddleware::class);
+$app->pipe(Middleware\UuidMiddleware::class);
+$app->pipe(Middleware\RequestTimeMiddleware::class);
+
+$app->pipeRoutingMiddleware();
+$app->pipe(Helper\UrlHelperMiddleware::class);
+$app->pipeDispatchMiddleware();
+
+// Add routed middleware
+$app->get('/', Action\HomePageAction::class, 'home');
+$app->get('/api/ping', Action\PingAction::class, 'api.ping');
+$app->get('/page/[{action}]', Action\PageAction::class, 'page');
+$app->get('/users', Action\UserListAction::class, 'user.list');
+$app->get('/users/dbal', Action\UserDbalListAction::class, 'user.dbal.list');
 
 $app->run();


### PR DESCRIPTION
As promised, this is the branch that refactors the application to programmatic usage; it does so by:
- removing the `routes` configuration from `config/autoload/routes.global.php` (it now defines only dependencies)
- Removes the `middleware_pipeline` configuration from `config/autoload/middleware-pipeline.global.php` (it now defines only dependencies)
- Adds sections to `public/index.php` to define the middleware pipeline and routed middleware programmatically.

You can either teach the workshop this way, or demonstrate it at the end.
